### PR TITLE
Remove test step from github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,6 @@ jobs:
     - name: Install dependencies
       run: flutter pub get
     
-    - name: Run tests
-      run: flutter test
-    
     - name: Get current version
       id: current_version
       run: |


### PR DESCRIPTION
Remove the 'Run tests' step from the release GitHub Action to accelerate the deployment workflow.

This change skips the `flutter test` execution during the release process, making deployments faster.