### PR TITLE
Hide mark present action for future events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Consistent Behavior**: Aligns with existing logic that hides action for past events
 
 ### Technical
-- **DancerActionsDialog**: Added `isFutureEvent` condition alongside existing `isPastEvent` logic
-- **Date Logic**: Uses `DateUtils.dateOnly()` to compare event date with current date
+- **EventStatusHelper**: Added `isFutureEvent()` method to match existing `isPastEvent()` pattern
+- **DancerActionsDialog**: Used EventStatusHelper for consistent date logic across the app
+- **Date Logic**: Leverages existing helper class architecture for event date comparisons
 - **Action Logging**: Enhanced logging to track both past and future event status
 - **Conditional Display**: "Mark Present" only appears when `!isPastEvent && !isFutureEvent` (today only)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,18 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - **Future Event Logic**: Enhanced "Mark Present" action visibility for better UX
-  - **Hide for Future Events**: "Mark Present" action now hidden for events scheduled after today
+  - **Hide for Far Future Events**: "Mark Present" action now hidden for events 1+ days in the future
   - **Prevent Invalid Actions**: Users can no longer mark presence for events that haven't happened yet
-  - **Logical Workflow**: Maintains presence marking only for current day events
-  - **Better Planning UX**: Planning tab now focuses on ranking and preparation for future events
-  - **Consistent Behavior**: Aligns with existing logic that hides action for past events
+  - **Consistent with EventScreen**: Uses same predicate that determines Planning-only tab visibility
+  - **Better Planning UX**: Far future events focus on ranking and preparation without attendance actions
+  - **Logical Workflow**: Aligns with existing UI patterns where far future events show only Planning tab
 
 ### Technical
-- **EventStatusHelper**: Added `isFutureEvent()` method to match existing `isPastEvent()` pattern
-- **DancerActionsDialog**: Used EventStatusHelper for consistent date logic across the app
-- **Date Logic**: Leverages existing helper class architecture for event date comparisons
-- **Action Logging**: Enhanced logging to track both past and future event status
-- **Conditional Display**: "Mark Present" only appears when `!isPastEvent && !isFutureEvent` (today only)
+- **DancerActionsDialog**: Uses existing `EventStatusHelper.isFarFutureEvent()` predicate for consistency
+- **UI Consistency**: Same logic that EventScreen uses for tab visibility now controls action visibility
+- **Date Logic**: Leverages established event categorization (far future = 1+ days away)
+- **Action Logging**: Enhanced logging to track both past and far future event status
+- **Conditional Display**: "Mark Present" only appears when `!isPastEvent && !isFarFutureEvent`
 
 ## [v2.2.2] - 2025-01-17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.2.3] - 2025-01-17
+
+### User Requests
+- Hide "Mark Present" action in planning tab if the event is a future one
+
+### Improved
+- **Future Event Logic**: Enhanced "Mark Present" action visibility for better UX
+  - **Hide for Future Events**: "Mark Present" action now hidden for events scheduled after today
+  - **Prevent Invalid Actions**: Users can no longer mark presence for events that haven't happened yet
+  - **Logical Workflow**: Maintains presence marking only for current day events
+  - **Better Planning UX**: Planning tab now focuses on ranking and preparation for future events
+  - **Consistent Behavior**: Aligns with existing logic that hides action for past events
+
+### Technical
+- **DancerActionsDialog**: Added `isFutureEvent` condition alongside existing `isPastEvent` logic
+- **Date Logic**: Uses `DateUtils.dateOnly()` to compare event date with current date
+- **Action Logging**: Enhanced logging to track both past and future event status
+- **Conditional Display**: "Mark Present" only appears when `!isPastEvent && !isFutureEvent` (today only)
+
 ## [v2.2.2] - 2025-01-17
 
 ### User Requests

--- a/lib/utils/event_status_helper.dart
+++ b/lib/utils/event_status_helper.dart
@@ -9,6 +9,11 @@ class EventStatusHelper {
     return eventDate.isBefore(DateUtils.dateOnly(DateTime.now()));
   }
 
+  /// Checks if an event is in the future (after today)
+  static bool isFutureEvent(DateTime eventDate) {
+    return eventDate.isAfter(DateUtils.dateOnly(DateTime.now()));
+  }
+
   /// Checks if an event is "old" (2+ days ago)
   /// Old events only show the Summary tab in EventScreen
   static bool isOldEvent(DateTime eventDate) {

--- a/lib/utils/event_status_helper.dart
+++ b/lib/utils/event_status_helper.dart
@@ -9,11 +9,6 @@ class EventStatusHelper {
     return eventDate.isBefore(DateUtils.dateOnly(DateTime.now()));
   }
 
-  /// Checks if an event is in the future (after today)
-  static bool isFutureEvent(DateTime eventDate) {
-    return eventDate.isAfter(DateUtils.dateOnly(DateTime.now()));
-  }
-
   /// Checks if an event is "old" (2+ days ago)
   /// Old events only show the Summary tab in EventScreen
   static bool isOldEvent(DateTime eventDate) {

--- a/lib/widgets/dancer_actions_dialog.dart
+++ b/lib/widgets/dancer_actions_dialog.dart
@@ -68,7 +68,8 @@ class _DancerActionsDialogState extends State<DancerActionsDialog> {
   Widget build(BuildContext context) {
     final isPastEvent =
         _event != null && EventStatusHelper.isPastEvent(_event!.date);
-    final isFutureEvent = _event != null && _event!.date.isAfter(DateUtils.dateOnly(DateTime.now()));
+    final isFutureEvent =
+        _event != null && EventStatusHelper.isFutureEvent(_event!.date);
 
     ActionLogger.logUserAction('DancerActionsDialog', 'dialog_opened', {
       'dancerId': widget.dancer.id,

--- a/lib/widgets/dancer_actions_dialog.dart
+++ b/lib/widgets/dancer_actions_dialog.dart
@@ -68,6 +68,7 @@ class _DancerActionsDialogState extends State<DancerActionsDialog> {
   Widget build(BuildContext context) {
     final isPastEvent =
         _event != null && EventStatusHelper.isPastEvent(_event!.date);
+    final isFutureEvent = _event != null && _event!.date.isAfter(DateUtils.dateOnly(DateTime.now()));
 
     ActionLogger.logUserAction('DancerActionsDialog', 'dialog_opened', {
       'dancerId': widget.dancer.id,
@@ -78,6 +79,7 @@ class _DancerActionsDialogState extends State<DancerActionsDialog> {
       'isPresent': widget.dancer.isPresent,
       'hasRanking': widget.dancer.hasRanking,
       'isPastEvent': isPastEvent,
+      'isFutureEvent': isFutureEvent,
     });
 
     if (_isLoading) {
@@ -95,8 +97,8 @@ class _DancerActionsDialogState extends State<DancerActionsDialog> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Presence toggle - hide for past events (most common action, put first)
-            if (!isPastEvent)
+            // Presence toggle - hide for past events and future events (most common action, put first)
+            if (!isPastEvent && !isFutureEvent)
               ListTile(
                 leading: Icon(
                   widget.dancer.isPresent

--- a/lib/widgets/dancer_actions_dialog.dart
+++ b/lib/widgets/dancer_actions_dialog.dart
@@ -68,8 +68,8 @@ class _DancerActionsDialogState extends State<DancerActionsDialog> {
   Widget build(BuildContext context) {
     final isPastEvent =
         _event != null && EventStatusHelper.isPastEvent(_event!.date);
-    final isFutureEvent =
-        _event != null && EventStatusHelper.isFutureEvent(_event!.date);
+    final isFarFutureEvent =
+        _event != null && EventStatusHelper.isFarFutureEvent(_event!.date);
 
     ActionLogger.logUserAction('DancerActionsDialog', 'dialog_opened', {
       'dancerId': widget.dancer.id,
@@ -80,7 +80,7 @@ class _DancerActionsDialogState extends State<DancerActionsDialog> {
       'isPresent': widget.dancer.isPresent,
       'hasRanking': widget.dancer.hasRanking,
       'isPastEvent': isPastEvent,
-      'isFutureEvent': isFutureEvent,
+      'isFarFutureEvent': isFarFutureEvent,
     });
 
     if (_isLoading) {
@@ -98,8 +98,8 @@ class _DancerActionsDialogState extends State<DancerActionsDialog> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Presence toggle - hide for past events and future events (most common action, put first)
-            if (!isPastEvent && !isFutureEvent)
+            // Presence toggle - hide for past events and far future events (most common action, put first)
+            if (!isPastEvent && !isFarFutureEvent)
               ListTile(
                 leading: Icon(
                   widget.dancer.isPresent


### PR DESCRIPTION
Hide "Mark Present" action for far future events to align with EventScreen tab visibility.